### PR TITLE
Update uspd.sty

### DIFF
--- a/uspd.sty
+++ b/uspd.sty
@@ -2,6 +2,7 @@
 
 \usepackage{rotating}
 \usepackage{ifthen}
+\newcommand{\No}{\textnumero} % Need for bable v 1.2
 
 \hoffset=-5.4mm
 \voffset=-20.4mm

--- a/uspd.sty
+++ b/uspd.sty
@@ -2,7 +2,7 @@
 
 \usepackage{rotating}
 \usepackage{ifthen}
-\newcommand{\No}{\textnumero} % Need for bable v 1.2
+\newcommand{\No}{\textnumero} % Need for babel v 1.2
 
 \hoffset=-5.4mm
 \voffset=-20.4mm


### PR DESCRIPTION
According to babel docs:
The macro \No is removed since the Cyrillic number sign is available on
keyboard and can also be typed using the \textnumero macro.